### PR TITLE
Merge Env Var Purge

### DIFF
--- a/include/DG_misc.h
+++ b/include/DG_misc.h
@@ -1,0 +1,786 @@
+/*
+ * Misc. useful public domain functions.
+ * Assumes a C99 compatible Compiler (gcc and clang tested) or MS Visual C++
+ *
+ * Copyright (C) 2015-2016 Daniel Gibson
+ *
+ * Homepage: https://github.com/DanielGibson/Snippets/
+ *
+ * Do:
+ *   #define DG_MISC_IMPLEMENTATION
+ * before you include this file in *one* of your .c/.cpp files.
+ * Ideally, this is the first thing you #include in that .c/.cpp file.
+ * Or second: #include <stdarg.h> before this to get DG_vsnprintf()
+ *
+ * The code uses assertions. You can #define DG_MISC_ASSERT(condition, message)
+ * to your own liking to overwrite (or deactivate) them, if you don't,
+ * the default is #define DG_MISC_ASSERT assert( (condition) && (message) )
+ *
+ * You can #define DG_MISC_DEF if you want to prepend anything to the
+ * function signatures (like "static", "inline", "__declspec(dllexport)", ...)
+ * Example: #define DG_MISC_DEF static inline
+ *
+ * Supported Microsoft Visual C++ Versions:
+ *  Tested MSVC 2013 and 2010 (it just works for them), and MSVC 6.0, which works
+ *  with little changes: you need to "typedef unsigned int uintptr_t;" before
+ *  #including this file (because back then they didn't have uintptr_t) and you
+ *  need to comment out the call to _vscprintf() in DG_vsnprintf(), because that
+ *  function wasn't supported either. In that case, DG_(v)snprintf() will
+ *  return -1 (instead of the needed buffer length), if the buffer was too small.
+ *  Might be similar for other MSVC versions between 6 and 2010, I didn't test.
+ *  I'm not gonna test MSVC6 regularly, maybe just use a newer compiler :-P
+ *
+ * License:
+ *  This software is dual-licensed to the public domain and under the following
+ *  license: you are granted a perpetual, irrevocable license to copy, modify,
+ *  publish, and distribute this file as you see fit.
+ *  No warranty implied; use at your own risk.
+ *
+ * So you can do whatever you want with this code, including copying it
+ * (or parts of it) into your own source.
+ * No need to mention me or this "license" in your code or docs, even though
+ * it would be appreciated, of course.
+ */
+
+#ifndef __DG_MISC_H__
+#define __DG_MISC_H__
+
+// this allows you to prepend stuff to function signatures, e.g. "static"
+#ifndef DG_MISC_DEF
+// by default it's empty
+#define DG_MISC_DEF
+#endif // DG_MISC_DEF
+
+// for size_t:
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// returns the full path to your executable, including the executable itself
+// returns empty string on error
+DG_MISC_DEF const char* DG_GetExecutablePath(void);
+
+// returns the full path to the directory your executable is in,
+// incl. (back)slash, but without the executable itself
+// returns empty string on error
+DG_MISC_DEF const char* DG_GetExecutableDir(void);
+
+// returns the filename of the executable, without the path
+// basically, DG_GetExecutableDir() concatenated with DG_GetExecutableFilename()
+//   is DG_GetExecutablePath()
+// returns empty string on error
+DG_MISC_DEF const char* DG_GetExecutableFilename(void);
+
+// copy up to n chars of str into a new string which is guaranteed to be
+// '\0'-terminated.
+// Needs to be free'd with free(), returns NULL if allocation failed
+DG_MISC_DEF char* DG_strndup(const char* str, size_t n);
+
+// copies up to dstsize-1 bytes from src to dst and ensures '\0' termination
+// returns the number of chars that would be written into a big enough dst
+// buffer without the terminating '\0'
+DG_MISC_DEF size_t DG_strlcpy(char* dst, const char* src, size_t dstsize);
+
+// appends src to the existing null-terminated(!) string in dst while making
+// sure that dst will not contain more than dstsize bytes incl. terminating '\0'
+// returns the number of chars that would be written into a big enough dst
+// buffer without the terminating '\0'
+DG_MISC_DEF size_t DG_strlcat(char* dst, const char* src, size_t dstsize);
+
+// See also https://www.freebsd.org/cgi/man.cgi?query=strlcpy&sektion=3
+// for details on strlcpy and strlcat.
+
+// search for needle in haystack, like strstr(), but for binary data.
+// haystack and needle are buffers with given lengths in byte and will be
+// interpreted as unsigned char* for comparison. the comparison used is like memcmp()
+// returns the address of the first match, or NULL if it wasn't found
+DG_MISC_DEF void* DG_memmem(const void* haystack, size_t haystacklen,
+                            const void* needle, size_t needlelen);
+
+// search for last occurence of needle in haystack, like DG_memmem() but backwards.
+// haystack and needle are buffers with given lengths in byte and will be
+// interpreted as unsigned char* for comparison. the comparison used is like memcmp()
+// returns the address of the last match, or NULL if it wasn't found
+DG_MISC_DEF void* DG_memrmem(const void* haystack, size_t haystacklen,
+                             const void* needle, size_t needlelen);
+
+// returns the last occurence byte c in buf (searching backwards from buf[buflen-1] on)
+// like strrchr(), but for binary data, or like memchr() but backwards.
+// returns NULL if c wasn't found in buf.
+DG_MISC_DEF void* DG_memrchr(const void* buf, unsigned char c, size_t buflen);
+
+// search for last occurence of needle in haystack, like strstr() but backwards.
+// also like DG_memrmem(), but for '\0'-terminated strings.
+// returns the address of the last match, or NULL if it wasn't found
+DG_MISC_DEF char* DG_strrstr(const char* haystack, const char* needle);
+
+// like strtok, but threadsafe - saves the context in context.
+// so do char* ctx; foo = DG_strtok_r(bar, " \t", &ctx);
+// See http://linux.die.net/man/3/strtok_r for more details
+DG_MISC_DEF char* DG_strtok_r(char* str, const char* delim, char** context);
+
+// on many platforms (incl. windows and freebsd) this implementation is faster
+// than the libc's strnlen(). on others (linux/glibc, OSX) it just calls the
+// ASM-optimized strnlen() provided by the libc.
+// I didn't bother to use a #define because strnlen() (in contrast to strlen())
+// is no compiler-builtin (at least for GCC) anyway.
+
+// returns the length of the '\0'-terminated string s in chars
+// if there is no '\0' in the first n chars, returns n
+DG_MISC_DEF size_t DG_strnlen(const char* s, size_t n);
+
+#ifndef _WIN32
+// other libc implementations have a fast strlen... use a #define so compilers
+// recognizes strlen and can optimize/use a builtin
+
+// returns the length of the '\0'-terminated string s in chars
+#define DG_strlen strlen
+
+// other libc implementors than Microsoft implemented (v)snprintf() properly.
+#define DG_snprintf snprintf
+#define DG_vsnprintf vsnprintf
+
+#else // it *is* _WIN32, DG_strlen(), DG_snprintf() and DG_vsnprintf(), implemented as functions on win32
+
+// returns the length of the '\0'-terminated string s in chars
+DG_MISC_DEF size_t DG_strlen(const char* s);
+
+// a snprintf() implementation that is conformant to C99 by ensuring
+// '\0'-termination of dst and returning the number of chars (without
+// terminating '\0') that would've been written to a big enough buffer
+// However, it still might do microsoft-specific printf formatting
+//   int DG_snprintf(char *dst, size_t size, const char *format, ...);
+
+// several different cases to do printf format checking with different compilers for DG_snprintf()
+#if defined(_MSC_VER) && _MSC_VER >= 1400 // MSVC2005 and newer have an annotation. only used in /analyze builds.
+	#include <CodeAnalysis\SourceAnnotations.h>
+	DG_MISC_DEF int DG_snprintf(char *dst, size_t size,
+	             [SA_FormatString(Style="printf")] const char *format, ...);
+#elif defined(__GNUC__) // mingw or similar, checking with GCC attribute
+	DG_MISC_DEF int DG_snprintf(char *dst, size_t size,
+	             const char *format, ...) __attribute__ ((format (printf, 3, 4)));
+#else // some other compiler, no printf format checking
+	DG_MISC_DEF int DG_snprintf(char *dst, size_t size, const char *format, ...);
+#endif // _MSC_VER or __GNUC__
+
+#ifdef va_start // it's a macro and defined if the user #included stdarg.h
+
+// a vsnprintf() implementation that is conformant to C99 by ensuring
+// '\0'-termination of dst and returning the number of chars (without
+// terminating '\0') that would've been written to a big enough buffer
+// However, it still might do microsoft-specific printf formatting
+DG_MISC_DEF int DG_vsnprintf(char *dst, size_t size, const char *format, va_list ap);
+
+#endif // va_start
+
+#endif // _WIN32
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+#endif // __DG_MISC_H__
+
+// ****************************************************************************
+// under here: implementations
+
+#ifdef DG_MISC_IMPLEMENTATION
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// DG_MISC_NO_GNU_SOURCE can be used to enforce usage of our own memrchr() and memmem() functions
+// on Linux - mostly relevant for testing (they should be faster than my implementation)
+
+#ifndef DG_MISC_ASSERT
+#define DG_MISC_ASSERT(cond, msg) assert( (cond) && (msg) )
+#include <assert.h>
+#endif
+
+#include <string.h>
+
+#include <stdlib.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <limits.h> // INT_MAX, maybe PATH_MAX
+
+// for uintptr_t:
+#ifndef _MSC_VER
+#include <stdint.h>
+#endif
+
+#if defined(__linux) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__)
+#include <unistd.h> // readlink(), amongst others
+#endif
+
+#ifdef __FreeBSD__
+#include <sys/sysctl.h> // for sysctl() to get path to executable
+#endif
+
+#ifdef _WIN32
+#include <windows.h> // GetModuleFileNameA()
+#endif
+
+#ifdef __APPLE__
+#include <mach-o/dyld.h> // _NSGetExecutablePath
+#endif
+
+#ifndef PATH_MAX
+// this is mostly for windows. windows has a MAX_PATH = 260 #define, but allows
+// longer paths anyway.. this might not be the maximum allowed length, but is
+// hopefully good enough for realistic usecases
+#define PATH_MAX 4096
+#define _DG__DEFINED_PATH_MAX
+#endif
+
+static void DG__SetExecutablePath(char* exePath)
+{
+	// !!! this assumes that exePath can hold PATH_MAX chars !!!
+
+#ifdef _WIN32
+
+	DWORD len = GetModuleFileNameA(NULL, exePath, PATH_MAX);
+	if(len <= 0 || len == PATH_MAX)
+	{
+		// an error occured, clear exe path
+		exePath[0] = '\0';
+	}
+
+#elif defined(__linux) || defined(__NetBSD__) || defined(__OpenBSD__)
+
+	// all the platforms that have /proc/$pid/exe or similar that symlink the
+	// real executable - basiscally Linux and the BSDs except for FreeBSD which
+	// doesn't enable proc by default and has a sysctl() for this
+	char buf[PATH_MAX] = {0};
+#ifdef __linux
+	snprintf(buf, sizeof(buf), "/proc/%d/exe", getpid());
+#else // the BSDs
+	snprintf(buf, sizeof(buf), "/proc/%d/file", getpid());
+#endif
+	// readlink() doesn't null-terminate!
+	int len = readlink(buf, exePath, PATH_MAX-1);
+	if (len <= 0)
+	{
+		// an error occured, clear exe path
+		exePath[0] = '\0';
+	}
+	else
+	{
+		exePath[len] = '\0';
+	}
+
+#elif defined(__FreeBSD__)
+
+	// the sysctl should also work when /proc/ is not mounted (which seems to
+	// be common on FreeBSD), so use it..
+	int name[4] = {CTL_KERN, KERN_PROC, KERN_PROC_PATHNAME, -1};
+	size_t len = PATH_MAX-1;
+	int ret = sysctl(name, sizeof(name)/sizeof(name[0]), exePath, &len, NULL, 0);
+	if(ret != 0)
+	{
+		// an error occured, clear exe path
+		exePath[0] = '\0';
+	}
+
+#elif defined(__APPLE__)
+
+	uint32_t bufSize = PATH_MAX;
+	if(_NSGetExecutablePath(exePath, &bufSize) != 0)
+	{
+		// WTF, PATH_MAX is not enough to hold the path?
+		// an error occured, clear exe path
+		exePath[0] = '\0';
+	}
+
+	// TODO: realpath() ?
+	// TODO: no idea what this is if the executable is in an app bundle
+
+#else
+
+#error "Unsupported Platform!" // feel free to add implementation for your platform and send me a patch
+
+#endif
+}
+
+DG_MISC_DEF const char* DG_GetExecutablePath(void)
+{
+	static char exePath[PATH_MAX] = {0};
+
+	if(exePath[0] != '\0') return exePath;
+
+	// the following code should only be executed at the first call of this function
+	DG__SetExecutablePath(exePath);
+
+	return exePath;
+}
+
+DG_MISC_DEF const char* DG_GetExecutableDir(void)
+{
+	static char exeDir[PATH_MAX] = {0};
+
+	if(exeDir[0] != '\0') return exeDir;
+
+	// the following code should only be executed at the first call of this function
+	const char* exePath = DG_GetExecutablePath();
+
+	if(exePath == NULL || exePath[0] == '\0') return exeDir;
+
+	DG_strlcpy(exeDir, exePath, PATH_MAX);
+
+	// cut off executable name
+	char* lastSlash = strrchr(exeDir, '/');
+#ifdef _WIN32
+	char* lastBackSlash = strrchr(exeDir, '\\');
+	if(lastSlash == NULL || lastBackSlash > lastSlash) lastSlash = lastBackSlash;
+#endif // _WIN32
+
+	if(lastSlash != NULL) lastSlash[1] = '\0'; // cut off after last (back)slash
+
+	return exeDir;
+}
+
+DG_MISC_DEF const char* DG_GetExecutableFilename(void)
+{
+	static const char* exeName = "";
+	if(exeName[0] != '\0') return exeName;
+
+	// the following code should only be executed at the first call of this function
+	const char* exePath = DG_GetExecutablePath();
+
+	if(exePath == NULL || exePath[0] == '\0') return exeName;
+
+	// cut off executable name
+	const char* lastSlash = strrchr(exePath, '/');
+#ifdef _WIN32
+	const char* lastBackSlash = strrchr(exePath, '\\');
+	if(lastSlash == NULL || lastBackSlash > lastSlash) lastSlash = lastBackSlash;
+#endif // _WIN32
+
+	if(lastSlash != NULL && lastSlash[1] != '\0')
+	{
+		// the filename starts after the last (back)slash
+		exeName = lastSlash+1;
+	}
+
+	return exeName;
+}
+
+DG_MISC_DEF char* DG_strndup(const char* str, size_t n)
+{
+	DG_MISC_ASSERT(str != NULL, "Don't call DG_strndup() with NULL!");
+
+	size_t len = DG_strnlen(str, n);
+	char* ret = (char*)malloc(len+1); // need one more byte for terminating 0
+	if(ret != NULL)
+	{
+		memcpy(ret, str, len);
+		ret[len] = '\0';
+	}
+	return ret;
+}
+
+// Notes on DG_strlcat() and DG_strlcpy():
+// My implementations use (DG_)strlen(), (DG_)strnlen() and memcpy(), which are
+// usually heavily optimized. Thus they're faster than the BSD strl*
+// implementations in most cases (those iterate the strings bytewise themselves)
+// - unless the function call overhead is higher than iterating the bytes,
+//   which only happens for very short strings and is negligible.
+//  Furthermore the speedup depends on how well optimized your libc is.)
+// Note that strlcat() is *not* the same as strncat(), which takes the max
+//  number of bytes that should be appended, which is mostly useless.
+// And that strlcpy() is *not* the same as strncpy(), which fills up the unused
+//  part of the buffer with '\0', but doesn't guarantee '\0'-termination if the
+//  buffer isn't big enough.. and thus is pretty useless.
+
+DG_MISC_DEF size_t DG_strlcpy(char* dst, const char* src, size_t dstsize)
+{
+	DG_MISC_ASSERT(src && dst, "Don't call strlcpy with NULL arguments!");
+	size_t srclen = DG_strlen(src);
+
+	if(dstsize != 0)
+	{
+		size_t numchars = dstsize-1;
+
+		if(srclen < numchars) numchars = srclen;
+
+		memcpy(dst, src, numchars);
+		dst[numchars] = '\0';
+	}
+	return srclen;
+}
+
+DG_MISC_DEF size_t DG_strlcat(char* dst, const char* src, size_t dstsize)
+{
+	DG_MISC_ASSERT(src && dst, "Don't call strlcat with NULL arguments!");
+
+	size_t dstlen = DG_strnlen(dst, dstsize);
+	size_t srclen = DG_strlen(src);
+
+	DG_MISC_ASSERT(dstlen != dstsize, "dst must contain null-terminated data with strlen < dstsize!");
+
+	// TODO: dst[dstsize-1] = '\0' to ensure null-termination and make wrong dstsize more obvious?
+
+	if(dstsize > 1 && dstlen < dstsize-1)
+	{
+		size_t numchars = dstsize-dstlen-1;
+
+		if(srclen < numchars) numchars = srclen;
+
+		memcpy(dst+dstlen, src, numchars);
+		dst[dstlen+numchars] = '\0';
+	}
+
+	return dstlen + srclen;
+}
+
+DG_MISC_DEF void* DG_memmem(const void* haystack, size_t haystacklen,
+                            const void* needle, size_t needlelen)
+{
+	DG_MISC_ASSERT((haystack != NULL || haystacklen == 0)
+			&& (needle != NULL || needlelen == 0),
+			"Don't pass NULL into DG_memmem(), unless the corresponding len is 0!");
+
+#if defined(_GNU_SOURCE) && !defined(DG_MISC_NO_GNU_SOURCE)
+	// glibc has a very optimized version of this, use that instead
+	return memmem(haystack, haystacklen, needle, needlelen);
+#else
+	unsigned char* h = (unsigned char*)haystack;
+	unsigned char* n = (unsigned char*)needle;
+
+	if(needlelen == 0) return (void*)haystack; // this is what glibc does..
+	if(haystacklen < needlelen) return NULL; // also handles haystacklen == 0
+
+	if(needlelen == 1) return (void*)memchr(haystack, n[0], haystacklen);
+
+	// TODO: knuth-morris-pratt or boyer-moore or something like that might be a lot faster.
+
+	// the byte after the last byte needle could start at so it'd still fit into haystack
+	unsigned char* afterlast = h + haystacklen - needlelen + 1;
+	// haystack length up to afterlast
+	size_t hlen_for_needle_start = afterlast - h;
+	int n0 = n[0];
+	unsigned char* n0candidate = (unsigned char*)memchr(h, n0, hlen_for_needle_start);
+
+	while(n0candidate != NULL)
+	{
+		if(memcmp(n0candidate+1, n+1, needlelen-1) == 0)
+		{
+			return (void*)n0candidate;
+		}
+
+		++n0candidate; // go on searching one byte after the last n0candidate
+		hlen_for_needle_start = afterlast - n0candidate;
+		n0candidate = (unsigned char*)memchr(n0candidate, n0, hlen_for_needle_start);
+	}
+
+	return NULL; // not found
+
+#endif // _GNU_SOURCE
+}
+
+
+DG_MISC_DEF void* DG_memrchr(const void* buf, unsigned char c, size_t buflen)
+{
+	DG_MISC_ASSERT(buf != NULL, "Don't pass NULL into DG_memrchr()!");
+#if defined(_GNU_SOURCE) && !defined(DG_MISC_NO_GNU_SOURCE)
+	// glibc has a very optimized version of this, use that instead
+	return (void*)memrchr(buf, c, buflen);
+#else
+
+	// TODO: this could use a variation of the trick used in DG_strnlen(), as described
+	//       on https://graphics.stanford.edu/~seander/bithacks.html#ValueInWord
+
+	unsigned char* cur = (unsigned char*)buf + buflen;
+	const unsigned char* b = (const unsigned char*)buf;
+	while(cur > b) // aborts immediately if buflen == 0
+	{
+		--cur;
+		if(*cur == c) return cur;
+	}
+
+	return NULL;
+#endif // _GNU_SOURCE
+}
+
+DG_MISC_DEF void* DG_memrmem(const void* haystack, size_t haystacklen,
+                             const void* needle, size_t needlelen)
+{
+	DG_MISC_ASSERT((haystack != NULL || haystacklen == 0)
+			&& (needle != NULL || needlelen == 0),
+			"Don't pass NULL into DG_memrmem(), unless the corresponding len is 0!");
+
+	unsigned char* h = (unsigned char*)haystack;
+	unsigned char* n = (unsigned char*)needle;
+
+	if(needlelen == 0) return (void*)(h+haystacklen); // this is kinda analog to DG_memmem()'s behavior
+	if(haystacklen < needlelen) return NULL; // also handles haystacklen == 0
+
+	if(needlelen == 1) return (void*)DG_memrchr(haystack, n[0], haystacklen);
+
+	// TODO: knuth-morris-pratt or boyer-moore or something like that might be a lot faster.
+
+	// the byte after the last byte needle could start at so it'd still fit into haystack
+	unsigned char* afterlast = h + haystacklen - needlelen + 1;
+	// haystack length up to afterlast
+	size_t hlen_for_needle_start = afterlast - h;
+	int n0 = n[0];
+	unsigned char* n0candidate = (unsigned char*)DG_memrchr(h, n0, hlen_for_needle_start);
+
+	while(n0candidate != NULL)
+	{
+		if(memcmp(n0candidate+1, n+1, needlelen-1) == 0)
+		{
+			return (void*)n0candidate;
+		}
+
+		// now n0candidate is the char *after* the end of the part of
+		// the string we still care about
+		hlen_for_needle_start = n0candidate - h;
+		n0candidate = (unsigned char*)DG_memrchr(h, n0, hlen_for_needle_start);
+	}
+
+	return NULL; // not found
+}
+
+DG_MISC_DEF char* DG_strrstr(const char* haystack, const char* needle)
+{
+	size_t hLen = DG_strlen(haystack);
+	size_t nLen = DG_strlen(needle);
+	return (char*)DG_memrmem(haystack, hLen, needle, nLen);
+}
+
+/* 
+ * public domain strtok_r() by Charlie Gordon
+ * see http://groups.google.com/group/comp.lang.c/msg/2ab1ecbb86646684
+ * and http://groups.google.com/group/comp.lang.c/msg/7c7b39328fefab9c
+ * with a fix from Fletcher T. Penney, also in public domain,
+ * see https://github.com/fletcher/MultiMarkdown-4/blob/master/strtok.c
+ */
+DG_MISC_DEF char* DG_strtok_r(char* str, const char* delim, char** context)
+{
+	DG_MISC_ASSERT(context && delim, "Don't call DG_strtok_r() with delim or context set to NULL!");
+	DG_MISC_ASSERT(str || *context, "Don't call DG_strtok_r() with *context and str both set to NULL!");
+
+#if !defined(DG_MISC_NO_GNU_SOURCE) && !defined(_WIN32)
+
+	// I think every interesting platform except for Windows supports strtok_r
+	// (if not, add it above with "&& !defined(_OTHER_CRAPPY_PLATFORM)")
+	return strtok_r(str, delim, context);
+
+#else // Windows
+
+	// I don't wanna use MSVC's strtok_s(), because C11 defines a function with
+	// that name but a totally different signature.. and it's not supported
+	// by old MSVC versions.
+	char* ret;
+
+	if (str == NULL) str = *context;
+
+	if (str == NULL) return NULL;
+
+	str += strspn(str, delim);
+
+	if (*str == '\0') return NULL;
+
+	ret = str;
+
+	str += strcspn(str, delim);
+
+	if (*str) *str++ = '\0';
+
+	*context = str;
+
+	return ret;
+#endif // _WIN32
+}
+
+DG_MISC_DEF size_t DG_strnlen(const char* s, size_t n)
+{
+	DG_MISC_ASSERT(s != NULL, "Don't call DG_strnlen() with NULL!");
+
+#if (defined(__GLIBC__) || defined(__APPLE__)) && !defined(DG_MISC_NO_GNU_SOURCE)
+	// glibc has a very optimized version of this, use that instead
+	// apple also seems to have optimized ASM code, see
+	// http://www.opensource.apple.com/source/Libc/Libc-1044.1.2/x86_64/string/
+	return strnlen(s, n);
+#else
+	// at least microsoft and freebsd seem to use a naive strnlen() without
+	// any tricks which is usually slower than this
+
+	// uses a trick from https://graphics.stanford.edu/~seander/bithacks.html#ZeroInWord
+	// (and probably in 1000 other places) to decide whether sizeof(uintptr_t) bytes
+	// contain a '\0' or not. without branching, with relatively few instructions
+	// that trick only works (at least in the way I've implemented it) with 32bit and 64bit systems
+	DG_MISC_ASSERT((sizeof(uintptr_t) == 4 || sizeof(uintptr_t) == 8), "DG_strnlen() only works for 32bit and 64bit systems!");
+	// these magic numbers are used for the trick:
+#if defined(_MSC_VER) && !defined(_WIN64)
+	// some older MSVC versions (tested 6.0) don't support ULL suffixes.. not sure
+	// when they started supporting them, but for non-64bit windows these constants works
+	static const uintptr_t magic1 = 0x01010101uL;
+	static const uintptr_t magic2 = 0x80808080uL;
+#else // better compilers/64bit win
+	static const uintptr_t magic1 = (sizeof(uintptr_t) == 4) ? 0x01010101uL : 0x0101010101010101uLL;
+	static const uintptr_t magic2 = (sizeof(uintptr_t) == 4) ? 0x80808080uL : 0x8080808080808080uLL;
+#endif
+
+	// let's get the empty buffer special case out of the way...
+	if(n==0) return 0;
+
+	// s aligned to the next word boundary
+	uintptr_t s_alnI = ((uintptr_t)s + sizeof(uintptr_t) - 1) & ~(sizeof(uintptr_t)-1);
+	const uintptr_t* s_aln = (uintptr_t *)s_alnI;
+	const char* s_last = (const char*)(~((uintptr_t)0)); // highest possible address (all bits are 1)
+
+	if(n < (uintptr_t)(s_last - s))
+	{
+		// adding n won't overflow, so it's safe to do that now.
+		// otherwise s_last will remain to be the highest possible address
+		// Note: this is a bit cryptic, but according to http://lwn.net/Articles/278137/
+		// a check like "if(s+n-1 < s)" might be optimized away by many compilers
+		
+		// now it points to the last but one byte in s (if no byte up to and
+		// including this one is '\0', we'll return n)
+		s_last = s+n-1;
+	}
+
+	// check bytes between s and s_aln
+	const char* cur = s;
+	for( ; cur < (const char*)s_aln; ++cur)
+	{
+		if(*cur == '\0')
+		{
+			if(cur > s_last) return n;
+
+			return cur - s;
+		}
+	}
+
+	for( ; (const char*)s_aln <= s_last; ++s_aln)
+	{
+		// the aforementioned trick
+		uintptr_t m1 = *s_aln - magic1;
+		uintptr_t m2 = (~(*s_aln)) & magic2;
+
+		if(m1 & m2)
+		{
+			cur = (const char*)s_aln;
+			size_t i;
+			for(i=0; i<sizeof(uintptr_t); ++i)
+			{
+				if(cur[i] == '\0')
+				{
+					size_t ret = cur + i - s;
+					return (ret < n) ? ret : n;
+				}
+			}
+		}
+	}
+
+	return n;
+
+#endif // __GLIBC__
+}
+
+#ifdef _WIN32
+/* value of _MSC_VER macro for different MSVC versions,
+ * so I don't have to google that over and over again
+ * (from http://sourceforge.net/p/predef/wiki/Compilers/#microsoft-visual-c)
+ * Visual C++   _MSC_VER
+ * 15.3 (2017)   1911 // "Visual Studio 2017 Version 15.3 Preview"
+ * 15.0 (2017)   1910
+ * 14.0 (2015)   1900
+ * 12.0 (2013)   1800
+ * 11.0 (2012)   1700
+ * 10.0 (2010)   1600
+ * 9.0  (2008)   1500
+ * 8.0  (2005)   1400 // first with 64bit support?
+ * 7.1  (2003)   1310
+ * 7.0           1300
+ * 6.0           1200
+ * 5.0           1100
+ * 4.2           1020
+ * 4.0           1000
+ * 3.0           900
+ * 1.0           800
+ */
+
+
+DG_MISC_DEF size_t DG_strlen(const char* s)
+{
+	// glibc's strlen() is *fucking* fast (with custom ASM), Apple also has custom ASM,
+	// freebsd uses the same trick as DG_strnlen() and is slightly faster...
+	// but Microsoft's strlen() is slower than DG_strnlen(), so use that for Windows.
+	// I don't feel like duplicating all that strnlen() code, so let's just pass
+	// the max. possible length (until the highest address a pointer can store)
+	static const char* maxaddr = (const char*)(~((uintptr_t)0));
+	return DG_strnlen(s, maxaddr - s);
+}
+
+DG_MISC_DEF int DG_vsnprintf(char *dst, size_t size, const char *format, va_list ap)
+{
+	DG_MISC_ASSERT(format, "Don't pass a NULL format into DG_vsnprintf()!");
+	// TODO: assert(size <= INT_MAX && "Don't pass a size > INT_MAX to DG_vsnprintf()!"); ??
+	//       after all, we're supposed to return the number of bytes written.. as an int.
+
+	int ret = -1;
+	if(dst != NULL && size > 0)
+	{
+#if defined(_MSC_VER) && _MSC_VER >= 1400
+		// I think MSVC2005 introduced _vsnprintf_s().
+		// this shuts up _vsnprintf() security/deprecation warnings.
+		ret = _vsnprintf_s(dst, size, _TRUNCATE, format, ap);
+#else
+		ret = _vsnprintf(dst, size, format, ap);
+		dst[size-1] = '\0'; // ensure '\0'-termination
+#endif
+	}
+
+	if(ret == -1)
+	{
+		// _vsnprintf() returns -1 if the output is truncated
+		// it's also -1 if dst or size were NULL/0, so the user didn't want to write
+		// we want to return the number of characters that would've been
+		// needed, though.. fortunately _vscprintf() calculates that.
+		ret = _vscprintf(format, ap);
+
+		// NOTE: on ancient MSVC versions you may get an error because
+		//  _vscprintf() is not supported.. I don't know when it started being
+		//  supported and I don't want to silently make this function incorrect
+		//  anyway.. feel free to comment out that line yourself, -1 will be
+		//  returned in case of a too short buffer then.
+		//  At least it'll still be '\0'-terminated.
+	}
+
+	return ret;
+}
+
+DG_MISC_DEF int DG_snprintf(char *dst, size_t size, const char *format, ...)
+{
+	DG_MISC_ASSERT(format, "Don't pass a NULL format into DG_snprintf()!");
+
+	int ret = 0;
+
+	va_list argptr;
+	va_start( argptr, format );
+
+	ret = DG_vsnprintf(dst, size, format, argptr);
+
+	va_end( argptr );
+
+	return ret;
+}
+#endif // _WIN32
+
+#ifdef _DG__DEFINED_PATH_MAX
+#undef PATH_MAX
+#undef _DG__DEFINED_PATH_MAX
+#endif // _DG__DEFINED_PATH_MAX
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+#endif // DG_MISC_IMPLEMENTATION

--- a/include/cute_path.h
+++ b/include/cute_path.h
@@ -1,0 +1,545 @@
+/*
+	------------------------------------------------------------------------------
+		Licensing information can be found at the end of the file.
+	------------------------------------------------------------------------------
+
+	cute_path.h - v1.01
+
+	To create implementation (the function definitions)
+		#define CUTE_PATH_IMPLEMENTATION
+	in *one* C/CPP file (translation unit) that includes this file
+
+	SUMMARY:
+
+		Collection of c-string manipulation functions for dealing with common file-path
+		operations. More or less a less-fully-featured replacement for Shlwapi.h path
+		functions on Windows.
+
+		Performs no dynamic memory management and has no external dependencies (other than
+		some crt funcs).
+
+	Revision history:
+		1.0  (11/01/2017) initial release
+		1.01 (11/10/2017) path_compact, path_pop bugfixes
+*/
+
+/*
+	Contributors:
+		sro5h             1.01 - path_compact, path_pop bugfixes
+*/
+
+#if !defined(CUTE_PATH_H)
+
+#define CUTE_PATH_MAX_PATH 1024
+#define CUTE_PATH_MAX_EXT 32
+
+// Copies path to out, but not the extension. Places a nul terminator in out.
+// Returns the length of the string in out, excluding the nul byte.
+// Length of copied output can be up to CUTE_PATH_MAX_PATH. Can also copy the file
+// extension into ext, up to CUTE_PATH_MAX_EXT.
+#if !defined(__cplusplus)
+int path_pop_ext(const char* path, char* out, char* ext);
+#else
+int path_pop_ext(const char* path, char* out = 0, char* ext = 0);
+#endif
+
+// Copies path to out, but excludes the final file or folder from the output.
+// If the final file or folder contains a period, the file or folder will
+// still be appropriately popped. If the path contains only one file or folder,
+// the output will contain a period representing the current directory. All
+// outputs are nul terminated.
+// Returns the length of the string in out, excluding the nul byte.
+// Length of copied output can be up to CUTE_PATH_MAX_PATH.
+// Optionally stores the popped filename in pop. pop can be NULL.
+// out can also be NULL.
+#if !defined(__cplusplus)
+int path_pop(const char* path, char* out, char* pop);
+#else
+int path_pop(const char* path, char* out = 0, char* pop = 0);
+#endif
+
+// Concatenates path_b onto the end of path_a. Will not write beyond max_buffer_length.
+// Places a single '/' character between path_a and path_b. Does no other "intelligent"
+// manipulation of path_a and path_b; it's a basic strcat kind of function.
+void path_concat(const char* path_a, const char* path_b, char* out, int max_buffer_length);
+
+// Copies the name of the folder the file sits in (but not the entire path) to out. Will
+// not write beyond max_buffer_length. Length of copied output can be up to CUTE_PATH_MAX_PATH.
+// path contains the full path to the file in question.
+// Returns 0 for inputs of "", "." or ".." as the path, 1 otherwise (success).
+int path_name_of_folder_im_in(const char* path, char* out);
+
+// Shrinks the path to the desired length n, the out buffer will never be bigger than
+// n + 1. Places three '.' between the last part of the path and the first part that
+// will be shortened to fit. If the last part is too long to fit in a string of length n,
+// the last part will be shortened to fit and three '.' will be added in front & back.
+int path_compact(const char* path, char* out, int n);
+
+// Some useful (but not yet implemented) functions
+/*
+	int path_root(const char* path, char* out);
+*/
+
+#define CUTE_PATH_UNIT_TESTS 1
+void path_do_unit_tests();
+
+#define CUTE_PATH_H
+#endif
+
+#ifdef CUTE_PATH_IMPLEMENTATION
+#ifndef CUTE_PATH_IMPLEMENTATION_ONCE
+#define CUTE_PATH_IMPLEMENTATION_ONCE
+
+#ifdef _WIN32
+
+	#if !defined(_CRT_SECURE_NO_WARNINGS)
+		#define _CRT_SECURE_NO_WARNINGS
+	#endif
+
+#endif
+
+#include <string.h> // strncpy, strncat, strlen
+#define CUTE_PATH_STRNCPY strncpy
+#define CUTE_PATH_STRNCAT strncat
+#define CUTE_PATH_STRLEN strlen
+
+int path_is_slash(char c)
+{
+	return (c == '/') | (c == '\\');
+}
+
+int path_pop_ext(const char* path, char* out, char* ext)
+{
+	int initial_skipped_periods = 0;
+	while (*path == '.')
+	{
+		++path;
+		++initial_skipped_periods;
+	}
+
+	const char* period = path;
+	char c;
+	while ((c = *period++)) if (c == '.') break;
+
+	int has_period = c == '.';
+	int len = (int)(period - path) - 1 + initial_skipped_periods;
+	if (len > CUTE_PATH_MAX_PATH - 1) len = CUTE_PATH_MAX_PATH - 1;
+
+	if (out)
+	{
+		CUTE_PATH_STRNCPY(out, path - initial_skipped_periods, len);
+		out[len] = 0;
+	}
+
+	if (ext)
+	{
+		if (has_period)
+		{
+			CUTE_PATH_STRNCPY(ext, path - initial_skipped_periods + len + 1, CUTE_PATH_MAX_EXT);
+		}
+		else
+		{
+			ext[0] = 0;
+		}
+	}
+	return len;
+}
+
+int path_pop(const char* path, char* out, char* pop)
+{
+	const char* original = path;
+	int total_len = 0;
+	while (*path)
+	{
+		++total_len;
+		++path;
+	}
+
+	// ignore trailing slash from input path
+	if (path_is_slash(*(path - 1)))
+	{
+		--path;
+		total_len -= 1;
+	}
+
+	int pop_len = 0; // length of substring to be popped
+	while (!path_is_slash(*--path) && pop_len != total_len)
+		++pop_len;
+	int len = total_len - pop_len; // length to copy
+
+        // don't ignore trailing slash if it is the first character
+        if (len > 1)
+        {
+                len -= 1;
+        }
+
+	if (len > 0)
+	{
+		if (out)
+		{
+			CUTE_PATH_STRNCPY(out, original, len);
+			out[len] = 0;
+		}
+
+		if (pop)
+		{
+			CUTE_PATH_STRNCPY(pop, path + 1, pop_len);
+			pop[pop_len] = 0;
+		}
+
+		return len;
+	}
+
+	else
+	{
+		if (out)
+		{
+			out[0] = '.';
+			out[1] = 0;
+		}
+		if (pop) *pop = 0;
+		return 1;
+	}
+}
+
+static int path_strncpy(char* dst, const char* src, int n, int max)
+{
+	int c;
+
+	do
+	{
+		if (n >= max - 1)
+		{
+			dst[max - 1] = 0;
+			break;
+		}
+		c = *src++;
+		dst[n] = c;
+		++n;
+	} while (c);
+
+	return n;
+}
+
+void path_concat(const char* path_a, const char* path_b, char* out, int max_buffer_length)
+{
+	int n = path_strncpy(out, path_a, 0, max_buffer_length);
+	n = path_strncpy(out, "/", n - 1, max_buffer_length);
+	path_strncpy(out, path_b, n - 1, max_buffer_length);
+}
+
+int path_name_of_folder_im_in(const char* path, char* out)
+{
+	// return failure for empty strings and "." or ".."
+	if (!*path || (*path == '.' && CUTE_PATH_STRLEN(path) < 3)) return 0;
+	int len = path_pop(path, out, NULL);
+	int has_slash = 0;
+	for (int i = 0; out[i]; ++i)
+	{
+		if (path_is_slash(out[i]))
+		{
+			has_slash = 1;
+			break;
+		}
+	}
+
+	if (has_slash)
+	{
+		int n = path_pop(out, NULL, NULL) + 1;
+		len -= n;
+		CUTE_PATH_STRNCPY(out, path + n, len);
+	}
+
+	else CUTE_PATH_STRNCPY(out, path, len);
+	out[len] = 0;
+	return 1;
+}
+
+int path_compact(const char* path, char* out, int n)
+{
+	if (n <= 6) return 0;
+
+	const char* sep = "...";
+	const int seplen = strlen(sep);
+
+	int pathlen = strlen(path);
+	out[0] = 0;
+
+	if (pathlen <= n)
+	{
+		CUTE_PATH_STRNCPY(out, path, pathlen);
+		out[pathlen] = 0;
+		return pathlen;
+	}
+
+	// Find last path separator
+	// Ignores the last character as it could be a path separator
+	int i = pathlen - 1;
+	do
+	{
+		--i;
+	} while (!path_is_slash(path[i]) && i > 0);
+
+	const char* back = path + i;
+	int backlen = strlen(back);
+
+	// No path separator was found or the first character was one
+	if (pathlen == backlen)
+	{
+		CUTE_PATH_STRNCPY(out, path, n - seplen);
+		out[n - seplen] = 0;
+		CUTE_PATH_STRNCAT(out, sep, seplen + 1);
+		return n;
+	}
+
+	// Last path part with separators in front equals n
+	if (backlen == n - seplen)
+	{
+		CUTE_PATH_STRNCPY(out, sep, seplen + 1);
+		CUTE_PATH_STRNCAT(out, back, backlen);
+		return n;
+	}
+
+	// Last path part with separators in front is too long
+	if (backlen > n - seplen)
+	{
+		CUTE_PATH_STRNCPY(out, sep, seplen + 1);
+		CUTE_PATH_STRNCAT(out, back, n - (2 * seplen));
+		CUTE_PATH_STRNCAT(out, sep, seplen);
+		return n;
+	}
+
+	int remaining = n - backlen - seplen;
+
+	CUTE_PATH_STRNCPY(out, path, remaining);
+	out[remaining] = 0;
+	CUTE_PATH_STRNCAT(out, sep, seplen);
+	CUTE_PATH_STRNCAT(out, back, backlen);
+
+	return n;
+}
+
+#if CUTE_PATH_UNIT_TESTS
+
+	#include <stdio.h>
+
+	#define CUTE_PATH_STRCMP strcmp
+	#define CUTE_PATH_EXPECT(X) do { if (!(X)) printf("Failed cute_path.h unit test at line %d of file %s.\n", __LINE__, __FILE__); } while (0)
+
+	void path_do_unit_tests()
+	{
+		char out[CUTE_PATH_MAX_PATH];
+                char pop[CUTE_PATH_MAX_PATH];
+                char ext[CUTE_PATH_MAX_PATH];
+                int n;
+
+		const char* path = "../root/file.ext";
+		path_pop_ext(path, out, ext);
+		CUTE_PATH_EXPECT(!CUTE_PATH_STRCMP(out, "../root/file"));
+		CUTE_PATH_EXPECT(!CUTE_PATH_STRCMP(ext, "ext"));
+
+		path_pop(path, out, pop);
+		CUTE_PATH_EXPECT(!CUTE_PATH_STRCMP(out, "../root"));
+		CUTE_PATH_EXPECT(!CUTE_PATH_STRCMP(pop, "file.ext"));
+
+		path = "../root/file";
+		path_pop_ext(path, out, ext);
+		CUTE_PATH_EXPECT(!CUTE_PATH_STRCMP(out, "../root/file"));
+		CUTE_PATH_EXPECT(!CUTE_PATH_STRCMP(ext, ""));
+
+		path_pop(path, out, pop);
+		CUTE_PATH_EXPECT(!CUTE_PATH_STRCMP(out, "../root"));
+		CUTE_PATH_EXPECT(!CUTE_PATH_STRCMP(pop, "file"));
+
+		path = "../root/";
+		path_pop_ext(path, out, ext);
+		CUTE_PATH_EXPECT(!CUTE_PATH_STRCMP(out, "../root/"));
+		CUTE_PATH_EXPECT(!CUTE_PATH_STRCMP(ext, ""));
+
+		path_pop(path, out, pop);
+		CUTE_PATH_EXPECT(!CUTE_PATH_STRCMP(out, ".."));
+		CUTE_PATH_EXPECT(!CUTE_PATH_STRCMP(pop, "root"));
+
+		path = "../root";
+		path_pop_ext(path, out, ext);
+		CUTE_PATH_EXPECT(!CUTE_PATH_STRCMP(out, "../root"));
+		CUTE_PATH_EXPECT(!CUTE_PATH_STRCMP(ext, ""));
+
+		path_pop(path, out, pop);
+		CUTE_PATH_EXPECT(!CUTE_PATH_STRCMP(out, ".."));
+		CUTE_PATH_EXPECT(!CUTE_PATH_STRCMP(pop, "root"));
+
+		path = "/file";
+		path_pop_ext(path, out, ext);
+		CUTE_PATH_EXPECT(!CUTE_PATH_STRCMP(out, "/file"));
+		CUTE_PATH_EXPECT(!CUTE_PATH_STRCMP(ext, ""));
+
+		path_pop(path, out, pop);
+		CUTE_PATH_EXPECT(!CUTE_PATH_STRCMP(out, "/"));
+		CUTE_PATH_EXPECT(!CUTE_PATH_STRCMP(pop, "file"));
+
+		path = "../";
+		path_pop_ext(path, out, ext);
+		CUTE_PATH_EXPECT(!CUTE_PATH_STRCMP(out, "../"));
+		CUTE_PATH_EXPECT(!CUTE_PATH_STRCMP(ext, ""));
+
+		path_pop(path, out, pop);
+		CUTE_PATH_EXPECT(!CUTE_PATH_STRCMP(out, "."));
+		CUTE_PATH_EXPECT(!CUTE_PATH_STRCMP(pop, ""));
+
+		path = "..";
+		path_pop_ext(path, out, ext);
+		CUTE_PATH_EXPECT(!CUTE_PATH_STRCMP(out, ".."));
+		CUTE_PATH_EXPECT(!CUTE_PATH_STRCMP(ext, ""));
+
+		path_pop(path, out, pop);
+		CUTE_PATH_EXPECT(!CUTE_PATH_STRCMP(out, "."));
+		CUTE_PATH_EXPECT(!CUTE_PATH_STRCMP(pop, ""));
+
+		path = ".";
+		path_pop_ext(path, out, ext);
+		CUTE_PATH_EXPECT(!CUTE_PATH_STRCMP(out, "."));
+		CUTE_PATH_EXPECT(!CUTE_PATH_STRCMP(ext, ""));
+
+		path_pop(path, out, pop);
+		CUTE_PATH_EXPECT(!CUTE_PATH_STRCMP(out, "."));
+		CUTE_PATH_EXPECT(!CUTE_PATH_STRCMP(pop, ""));
+
+		path = "";
+		path_pop_ext(path, out, ext);
+		CUTE_PATH_EXPECT(!CUTE_PATH_STRCMP(out, ""));
+		CUTE_PATH_EXPECT(!CUTE_PATH_STRCMP(ext, ""));
+
+		path_pop(path, out, pop);
+		CUTE_PATH_EXPECT(!CUTE_PATH_STRCMP(out, "."));
+		CUTE_PATH_EXPECT(!CUTE_PATH_STRCMP(pop, ""));
+
+		path = "asdf/file.ext";
+		path_name_of_folder_im_in(path, out);
+		CUTE_PATH_EXPECT(!CUTE_PATH_STRCMP(out, "asdf"));
+
+		path = "asdf/lkjh/file.ext";
+		path_name_of_folder_im_in(path, out);
+		CUTE_PATH_EXPECT(!CUTE_PATH_STRCMP(out, "lkjh"));
+
+		path = "poiu/asdf/lkjh/file.ext";
+		path_name_of_folder_im_in(path, out);
+		CUTE_PATH_EXPECT(!CUTE_PATH_STRCMP(out, "lkjh"));
+
+		path = "poiu/asdf/lkjhqwer/file.ext";
+		path_name_of_folder_im_in(path, out);
+		CUTE_PATH_EXPECT(!CUTE_PATH_STRCMP(out, "lkjhqwer"));
+
+		path = "../file.ext";
+		path_name_of_folder_im_in(path, out);
+		CUTE_PATH_EXPECT(!CUTE_PATH_STRCMP(out, ".."));
+
+		path = "./file.ext";
+		path_name_of_folder_im_in(path, out);
+		CUTE_PATH_EXPECT(!CUTE_PATH_STRCMP(out, "."));
+
+		path = "..";
+		CUTE_PATH_EXPECT(!path_name_of_folder_im_in(path, out));
+
+		path = ".";
+		CUTE_PATH_EXPECT(!path_name_of_folder_im_in(path, out));
+
+		path = "";
+		CUTE_PATH_EXPECT(!path_name_of_folder_im_in(path, out));
+
+		const char* path_a = "asdf";
+		const char* path_b = "qwerzxcv";
+		path_concat(path_a, path_b, out, CUTE_PATH_MAX_PATH);
+		CUTE_PATH_EXPECT(!CUTE_PATH_STRCMP(out, "asdf/qwerzxcv"));
+
+		path_a = "path/owoasf.as.f.q.e.a";
+		path_b = "..";
+		path_concat(path_a, path_b, out, CUTE_PATH_MAX_PATH);
+		CUTE_PATH_EXPECT(!CUTE_PATH_STRCMP(out, "path/owoasf.as.f.q.e.a/.."));
+
+		path_a = "a/b/c";
+		path_b = "d/e/f/g/h/i";
+		path_concat(path_a, path_b, out, CUTE_PATH_MAX_PATH);
+		CUTE_PATH_EXPECT(!CUTE_PATH_STRCMP(out, "a/b/c/d/e/f/g/h/i"));
+
+		path = "/path/to/file.vim";
+		n = path_compact(path, out, 17);
+		CUTE_PATH_EXPECT(!CUTE_PATH_STRCMP(out, "/path/to/file.vim"));
+		CUTE_PATH_EXPECT(n == CUTE_PATH_STRLEN(out));
+
+		path = "/path/to/file.vim";
+		n = path_compact(path, out, 16);
+		CUTE_PATH_EXPECT(!CUTE_PATH_STRCMP(out, "/pat.../file.vim"));
+		CUTE_PATH_EXPECT(n == CUTE_PATH_STRLEN(out));
+
+		path = "/path/to/file.vim";
+		n = path_compact(path, out, 12);
+		CUTE_PATH_EXPECT(!CUTE_PATH_STRCMP(out, ".../file.vim"));
+		CUTE_PATH_EXPECT(n == CUTE_PATH_STRLEN(out));
+
+		path = "/path/to/file.vim";
+		n = path_compact(path, out, 11);
+		CUTE_PATH_EXPECT(!CUTE_PATH_STRCMP(out, ".../file..."));
+		CUTE_PATH_EXPECT(n == CUTE_PATH_STRLEN(out));
+
+		path = "longfile.vim";
+		n = path_compact(path, out, 12);
+		CUTE_PATH_EXPECT(!CUTE_PATH_STRCMP(out, "longfile.vim"));
+		CUTE_PATH_EXPECT(n == CUTE_PATH_STRLEN(out));
+
+		path = "longfile.vim";
+		n = path_compact(path, out, 11);
+		CUTE_PATH_EXPECT(!CUTE_PATH_STRCMP(out, "longfile..."));
+		CUTE_PATH_EXPECT(n == CUTE_PATH_STRLEN(out));
+	}
+
+#else
+
+	void path_do_unit_tests()
+	{
+	}
+
+#endif // CUTE_PATH_UNIT_TESTS
+
+#endif // CUTE_PATH_IMPLEMENTATION_ONCE
+#endif // CUTE_PATH_IMPLEMENTATION
+
+/*
+	------------------------------------------------------------------------------
+	This software is available under 2 licenses - you may choose the one you like.
+	------------------------------------------------------------------------------
+	ALTERNATIVE A - zlib license
+	Copyright (c) 2017 Randy Gaul http://www.randygaul.net
+	This software is provided 'as-is', without any express or implied warranty.
+	In no event will the authors be held liable for any damages arising from
+	the use of this software.
+	Permission is granted to anyone to use this software for any purpose,
+	including commercial applications, and to alter it and redistribute it
+	freely, subject to the following restrictions:
+	  1. The origin of this software must not be misrepresented; you must not
+	     claim that you wrote the original software. If you use this software
+	     in a product, an acknowledgment in the product documentation would be
+	     appreciated but is not required.
+	  2. Altered source versions must be plainly marked as such, and must not
+	     be misrepresented as being the original software.
+	  3. This notice may not be removed or altered from any source distribution.
+	------------------------------------------------------------------------------
+	ALTERNATIVE B - Public Domain (www.unlicense.org)
+	This is free and unencumbered software released into the public domain.
+	Anyone is free to copy, modify, publish, use, compile, sell, or distribute this 
+	software, either in source code form or as a compiled binary, for any purpose, 
+	commercial or non-commercial, and by any means.
+	In jurisdictions that recognize copyright laws, the author or authors of this 
+	software dedicate any and all copyright interest in the software to the public 
+	domain. We make this dedication for the benefit of the public at large and to 
+	the detriment of our heirs and successors. We intend this dedication to be an 
+	overt act of relinquishment in perpetuity of all present and future rights to 
+	this software under copyright law.
+	THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
+	IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+	FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
+	AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN 
+	ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION 
+	WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+	------------------------------------------------------------------------------
+*/

--- a/src/data/loadESRIShapefile.cc
+++ b/src/data/loadESRIShapefile.cc
@@ -1,77 +1,82 @@
-#include "libshape/shapefil.h"
 #include <iostream>
 #include <vector>
+
+#include "libshape/shapefil.h"
 
 using namespace std;
 
 void loadESRIShapefile(const char filename[]) {
-    SHPHandle shapeHandle = SHPOpen(filename, "rb");
-    int nEntities = shapeHandle->nRecords;
-    int nShapeType = shapeHandle->nShapeType;
+  SHPHandle shapeHandle = SHPOpen(filename, "rb");
+  int nEntities = shapeHandle->nRecords;
+  int nShapeType = shapeHandle->nShapeType;
 
-    uint64_t numPoints = 0;
-    uint32_t numSegments = 0;
-    vector<SHPObject*> shapes(nEntities);
-    for (int i = 0; i < nEntities; i++) {
-        SHPObject* shape = SHPReadObject(shapeHandle, i);
-        if (shape == nullptr) {
-            std::cerr << "Warning: error reading shape " << i << "\n";
-            continue;
-        }
-        numPoints += shape->nVertices;
-        numSegments += shape->nParts;
-        shapes[i] = shape;
+  uint64_t numPoints = 0;
+  uint32_t numSegments = 0;
+  vector<SHPObject*> shapes(nEntities);
+  for (int i = 0; i < nEntities; i++) {
+    SHPObject* shape = SHPReadObject(shapeHandle, i);
+    if (shape == nullptr) {
+      std::cerr << "Warning: error reading shape " << i << "\n";
+      continue;
+    }
+    numPoints += shape->nVertices;
+    numSegments += shape->nParts;
+    shapes[i] = shape;
+  }
+
+  vector<uint32_t> startPoly(
+      numSegments);  // preallocate correct number of polygons
+  vector<float> points(numPoints * 2);  // preallocate correct number of floats
+  uint32_t pointOffset = 0;             // track current point
+  for (uint32_t i = 0; i < shapes.size(); i++) {
+    int* start = shapes[i]->panPartStart;
+    if (start == nullptr && shapes[i]->nParts != 0) {
+      cerr << "Error null list of offsets shape=" << i
+           << " for parts panpartstart\n";
+      // TODO: // exception
+      return;
     }
 
-    vector<uint32_t> startPoly(numSegments); // preallocate correct number of polygons
-    vector<float> points(numPoints*2);       // preallocate correct number of floats
-    uint32_t pointOffset = 0;  // track current point
-    for (uint32_t i = 0; i < shapes.size(); i++) {
-        int* start = shapes[i]->panPartStart;
-        if (start == nullptr && shapes[i]->nParts != 0) {
-            cerr << "Error null list of offsets shape=" << i << " for parts panpartstart\n";
-            // TODO: // exception
-            return;
-        }
-
-        for (uint32_t j = 0; j < shapes[i]->nParts; j++) {
-            uint32_t numPointsPerSeg = j == shapes[i]->nParts - 1 ?
-                shapes[i]->nVertices - start[j] : start[j + 1] - start[j];
-            for (uint32_t k = 0; k < numPointsPerSeg; k++) {
-                points[pointOffset++] = shapes[i]->padfX[start[j] + k];
-                points[pointOffset++] = shapes[i]->padfY[start[j] + k];
-            }
-        }
+    for (uint32_t j = 0; j < shapes[i]->nParts; j++) {
+      uint32_t numPointsPerSeg = j == shapes[i]->nParts - 1
+                                     ? shapes[i]->nVertices - start[j]
+                                     : start[j + 1] - start[j];
+      for (uint32_t k = 0; k < numPointsPerSeg; k++) {
+        points[pointOffset++] = shapes[i]->padfX[start[j] + k];
+        points[pointOffset++] = shapes[i]->padfY[start[j] + k];
+      }
     }
-    for (auto shape : shapes)
-        SHPDestroyObject(shape);
-    SHPClose(shapeHandle);
+  }
+  for (auto shape : shapes) SHPDestroyObject(shape);
+  SHPClose(shapeHandle);
 }
 
 void loadESRIDBF(const char filename[]) {
-    DBFHandle dbf = DBFOpen(filename, "rb");
-    int numFields = DBFGetFieldCount(dbf);
-    char fieldName[12]; // must be at least 12 bytes
-    int fieldWidth;
-    int precision;
-    for (int i = 0; i < numFields; i++) {
-        DBFFieldType t = DBFGetFieldInfo(dbf, i, fieldName, &fieldWidth, &precision);
-        cout << fieldName << '\t' << fieldWidth << '\t' << precision << '\n';
-    }
+  DBFHandle dbf = DBFOpen(filename, "rb");
+  int numFields = DBFGetFieldCount(dbf);
+  char fieldName[12];  // must be at least 12 bytes
+  int fieldWidth;
+  int precision;
+  for (int i = 0; i < numFields; i++) {
+    DBFFieldType t =
+        DBFGetFieldInfo(dbf, i, fieldName, &fieldWidth, &precision);
+    cout << fieldName << '\t' << fieldWidth << '\t' << precision << '\n';
+  }
 
-    int recordCount = DBFGetRecordCount(dbf);
-    int SQMI = DBFGetFieldIndex(dbf, "SQMI"); // get index of this field
-    for (int i = 0; i < recordCount; i++) {
-        cout << DBFReadStringAttribute(dbf, i, 2) << '\t'
-             << DBFReadStringAttribute(dbf, i, 3) << '\t'
-             << DBFReadStringAttribute(dbf, i, 4) << '\t'
-             << DBFReadStringAttribute(dbf, i, 5) << '\t'
-             << DBFReadStringAttribute(dbf, i, 7) << '\t' // population
-             //<< DBFReadStringAttribute(dbf, i, 7) << '\t' // lat?
-             //<< DBFReadStringAttribute(dbf, i, 7) << '\t' // lon?
-             << DBFReadStringAttribute(dbf, i, SQMI) << '\n';
-    }
-    DBFClose(dbf);
+  int recordCount = DBFGetRecordCount(dbf);
+  int SQMI = DBFGetFieldIndex(dbf, "SQMI");  // get index of this field
+  for (int i = 0; i < recordCount; i++) {
+    cout << DBFReadStringAttribute(dbf, i, 2) << '\t'
+         << DBFReadStringAttribute(dbf, i, 3) << '\t'
+         << DBFReadStringAttribute(dbf, i, 4) << '\t'
+         << DBFReadStringAttribute(dbf, i, 5) << '\t'
+         << DBFReadStringAttribute(dbf, i, 7)
+         << '\t'  // population
+         //<< DBFReadStringAttribute(dbf, i, 7) << '\t' // lat?
+         //<< DBFReadStringAttribute(dbf, i, 7) << '\t' // lon?
+         << DBFReadStringAttribute(dbf, i, SQMI) << '\n';
+  }
+  DBFClose(dbf);
 }
 #if 0
 template<typename... Args>
@@ -80,11 +85,11 @@ string buildString(Args...template) {
 }
 #endif
 
-int main() {
-    string dir = getenv("GRAIL"); dir += "/test/res/maps/";
-    cout << "dir: " << dir << '\n';
-    loadESRIShapefile((dir + "USA_Counties.shp").c_str());
-    loadESRIDBF((dir + "USA_Counties.dbf").c_str());
-//    string data = buildString(getenv("GRAILDATA"), "/maps/c_10nv20.dbf");
-//    loadESRIDBF((dir + "USA_Counties.dbf").c_str());
-}
+// int main() {
+//     string dir = getenv("GRAIL"); dir += "/test/res/maps/";
+//     cout << "dir: " << dir << '\n';
+//     loadESRIShapefile((dir + "USA_Counties.shp").c_str());
+//     loadESRIDBF((dir + "USA_Counties.dbf").c_str());
+// //    string data = buildString(getenv("GRAILDATA"), "/maps/c_10nv20.dbf");
+// //    loadESRIDBF((dir + "USA_Counties.dbf").c_str());
+// }

--- a/src/opengl/GLWin.cc
+++ b/src/opengl/GLWin.cc
@@ -12,6 +12,7 @@
 #include <string>
 #include <vector>
 
+#include "DG_misc.h"
 #include "opengl/Errcode.hh"
 #include "util/Ex.hh"
 
@@ -238,7 +239,12 @@ void GLWin::startWindow() {
   // singleton initialization here
   // TODO: is there any more elegant way?
   if (!hasBeenInitialized) {
-    *(string *)&baseDir = getenv("GRAIL");
+    std::string tmp = DG_GetExecutableDir();
+    cout << tmp << endl;
+    tmp.erase(tmp.end() - 4, tmp.end());
+    cout << tmp << endl;
+    *(string *)&baseDir = tmp;
+    cout << "Basedir in glwin: " << baseDir << endl;
     FontFace::initAll();
   }
   defaultFont = (Font *)FontFace::get("TIMES", 16, FontFace::BOLD);

--- a/src/opengl/GLWin.cc
+++ b/src/opengl/GLWin.cc
@@ -12,7 +12,6 @@
 #include <string>
 #include <vector>
 
-#include "DG_misc.h"
 #include "opengl/Errcode.hh"
 #include "util/Ex.hh"
 
@@ -239,12 +238,7 @@ void GLWin::startWindow() {
   // singleton initialization here
   // TODO: is there any more elegant way?
   if (!hasBeenInitialized) {
-    std::string tmp = DG_GetExecutableDir();
-    cout << tmp << endl;
-    tmp.erase(tmp.end() - 4, tmp.end());
-    cout << tmp << endl;
-    *(string *)&baseDir = tmp;
-    cout << "Basedir in glwin: " << baseDir << endl;
+    baseDir = prefs.getBaseDir();
     FontFace::initAll();
   }
   defaultFont = (Font *)FontFace::get("TIMES", 16, FontFace::BOLD);

--- a/src/opengl/GLWinFonts.cc
+++ b/src/opengl/GLWinFonts.cc
@@ -475,14 +475,14 @@ void FontFace::initAll() {
   // if (hasBeenInitialized) return;
   // hasBeenInitialized = true;
   // TODO: load from config file
-  std::string fontPath = GLWin::baseDir + "/conf/fonts/";
+  std::string fontPath = GLWin::baseDir + "conf/fonts/";
   cout << "FONT PATH = " << fontPath << endl;
 
   if (FT_Init_FreeType(&FontFace::ftLib))
     throw Ex1(Errcode::INITIALIZE_FREETYPE);
   // Create a hashmap with the name and filepath of all fonts specified in
   // dirPaths
-  string baseDir = getBaseDir();
+  string baseDir = GLWin::baseDir;
   string fontBase = baseDir + "conf/fonts/";
   ifstream fontConf(baseDir + "conf/fonts.conf");
   string faceName, facePath;

--- a/src/opengl/GLWinFonts.cc
+++ b/src/opengl/GLWinFonts.cc
@@ -237,10 +237,6 @@ void FontFace::emptyFaces() {
   faces.clear();
 }
 
-string getBaseDir() {
-  string baseDir = getenv("GRAIL");
-  return baseDir + "/";
-}
 unordered_map<string, string> FontFace::pathByName;
 
 void FontFace::setTexture(const uint8_t bitmap[], uint32_t w, uint32_t h) {
@@ -411,7 +407,7 @@ void FontFace::saveFonts(const uint8_t* combinedBitmap,
                          uint32_t totalWidthAllFaces,
                          uint32_t maxHeightAllFaces) {
   ofstream fastfont(
-      getBaseDir() + "fast.glfont",
+      GLWin::baseDir + "fast.glfont",
       ios::binary);  // save a binary file for rapid loading next time
   FastFontHeader header;
   header.magic = 0x544E4644;

--- a/src/util/Prefs.cc
+++ b/src/util/Prefs.cc
@@ -1,67 +1,67 @@
 #include "util/Prefs.hh"
+
 #include <sys/stat.h>
+
 #include <fstream>
+#include <iostream>
+
+#define DG_MISC_IMPLEMENTATION
+#include "DG_misc.h"
 
 using namespace std;
-Prefs::Prefs() :
-	baseDir(getenv("GRAIL")),
-	preferredX(0), preferredY(0),
-	preferredWidth(1024), preferredHeight(1024),
-	allowMaximize(false),
-	logPath(baseDir + "log/log.txt"),
-	logLevel(5),
-	enableVoiceCmd(false),
-	shaderBinaryFormat(0),
-	fastLoadShaders(false),
-	trySavingShader(true)
-{
-	baseDir += "/";
+Prefs::Prefs()
+    : baseDir(DG_GetExecutableDir()),
+      preferredX(0),
+      preferredY(0),
+      preferredWidth(1024),
+      preferredHeight(1024),
+      allowMaximize(false),
+      logPath(baseDir + "log/log.txt"),
+      logLevel(5),
+      enableVoiceCmd(false),
+      shaderBinaryFormat(0),
+      fastLoadShaders(false),
+      trySavingShader(true) {
+  baseDir.erase(baseDir.end() - 4, baseDir.end());
+  cout << "BaseDir: " << baseDir << endl;
 }
 
 inline string Prefs::getGrailDir() const {
-	string HOME = getenv("HOME"); //TODO: on windows, HOMEPATH
+  string HOME = getenv("HOME");  // TODO: on windows, HOMEPATH
   return HOME + "/.grail/";
 }
 
-inline string Prefs::getPath() const {
-	return getGrailDir() + "prefs.conf";
-}
-	
+inline string Prefs::getPath() const { return getGrailDir() + "prefs.conf"; }
+
 void Prefs::save() {
   ofstream f(getPath().c_str());
-	f <<
-		baseDir << '\n' <<
-		preferredX << '\t' <<	preferredY << '\t' <<	preferredWidth << '\t' <<	preferredHeight << '\n' <<
-		allowMaximize << '\n' <<
-		logPath << '\n' <<
-		logLevel << '\n' <<
-		enableVoiceCmd << '\n' <<
-		shaderBinaryFormat << '\n' <<
-		fastLoadShaders << '\n' <<
-		trySavingShader << '\n';
+  f << baseDir << '\n'
+    << preferredX << '\t' << preferredY << '\t' << preferredWidth << '\t'
+    << preferredHeight << '\n'
+    << allowMaximize << '\n'
+    << logPath << '\n'
+    << logLevel << '\n'
+    << enableVoiceCmd << '\n'
+    << shaderBinaryFormat << '\n'
+    << fastLoadShaders << '\n'
+    << trySavingShader << '\n';
 }
 
 void Prefs::load() {
   ifstream f(getPath().c_str());
-	if (!f.good()) {
+  if (!f.good()) {
 #ifdef __linux__
-		mkdir(getGrailDir().c_str(), 0755);
+    mkdir(getGrailDir().c_str(), 0755);
 #elif _WIN32
-		mkdir(getGrailDir().c_str());
+    mkdir(getGrailDir().c_str());
 #endif
-		save();
-		return;
-	}
-	f >>
-		baseDir >>
-		preferredX >>	preferredY >>	preferredWidth >>	preferredHeight >>
-		allowMaximize >>
-		logPath >>
-		logLevel >>
-		enableVoiceCmd >>
-		shaderBinaryFormat >>
-		fastLoadShaders >>
-		trySavingShader;
+    save();
+    return;
+  }
+  f >> baseDir >> preferredX >> preferredY >> preferredWidth >>
+      preferredHeight >> allowMaximize >> logPath >> logLevel >>
+      enableVoiceCmd >> shaderBinaryFormat >> fastLoadShaders >>
+      trySavingShader;
 }
 
 Prefs prefs;

--- a/src/util/Prefs.cc
+++ b/src/util/Prefs.cc
@@ -8,10 +8,12 @@
 #define DG_MISC_IMPLEMENTATION
 #include "DG_misc.h"
 
+#define CUTE_PATH_IMPLEMENTATION
+#include "cute_path.h"
+
 using namespace std;
 Prefs::Prefs()
-    : baseDir(DG_GetExecutableDir()),
-      preferredX(0),
+    : preferredX(0),
       preferredY(0),
       preferredWidth(1024),
       preferredHeight(1024),
@@ -22,7 +24,15 @@ Prefs::Prefs()
       shaderBinaryFormat(0),
       fastLoadShaders(false),
       trySavingShader(true) {
-  baseDir.erase(baseDir.end() - 4, baseDir.end());
+  const char *full_path = DG_GetExecutableDir();
+
+  char out[CUTE_PATH_MAX_PATH];
+
+  path_pop(full_path, out);
+
+  baseDir = out;
+  baseDir += '/';
+
   cout << "BaseDir: " << baseDir << endl;
 }
 

--- a/src/util/Prefs.hh
+++ b/src/util/Prefs.hh
@@ -1,37 +1,36 @@
 #pragma once
 
 #include <string>
+
 class Prefs {
-private:
-	std::string baseDir;                           // location of all grail files
-	uint32_t preferredWidth, preferredHeight; // desired window size
-	uint32_t preferredX, preferredY;          // desired window location
-	bool allowMaximize;              // allow a web page to maximize the window?
-	std::string logPath;                      // path of the log file
-	uint32_t logLevel;                        // level of verbosity
-	bool     enableVoiceCmd;                  // will allow Sphinx input
-	uint32_t shaderBinaryFormat;              // found binary format for shaders
-	bool fastLoadShaders;                     // if true, then fast load instead of compiling
-	std::string getPath() const;              // get the path for the preferences file
-	std::string getGrailDir() const;          // get the path for the preferences file
-public:
-	Prefs();
-	void load();
-	void save();
+ private:
+  std::string baseDir;                       // location of all grail files
+  uint32_t preferredWidth, preferredHeight;  // desired window size
+  uint32_t preferredX, preferredY;           // desired window location
+  bool allowMaximize;           // allow a web page to maximize the window?
+  std::string logPath;          // path of the log file
+  uint32_t logLevel;            // level of verbosity
+  bool enableVoiceCmd;          // will allow Sphinx input
+  uint32_t shaderBinaryFormat;  // found binary format for shaders
+  bool fastLoadShaders;         // if true, then fast load instead of compiling
+  std::string getPath() const;  // get the path for the preferences file
+  std::string getGrailDir() const;  // get the path for the preferences file
+ public:
+  Prefs();
+  void load();
+  void save();
 
-	bool trySavingShader;                     // set true first, if it fails, set false
+  bool trySavingShader;  // set true first, if it fails, set false
 
-	std::string getConfDir() const { return baseDir + "conf/"; }
-	std::string getFontDir() const { return baseDir + "conf/fonts/"; }
-	std::string getShaderDir() const { return baseDir + "shaders/"; }
-	uint32_t getPreferredX() const { return preferredX; }
-	uint32_t getPreferredY() const { return preferredY; }
-	uint32_t getPreferredWidth() const { return preferredWidth; }
-	uint32_t getPreferredHeight() const { return preferredHeight; }
-	bool getFastLoadShaders() const { return shaderBinaryFormat != 0;}
-	void setFastLoadShaders(uint32_t fmt) {
-		shaderBinaryFormat = fmt;
-	}	
+  std::string getConfDir() const { return baseDir + "conf/"; }
+  std::string getFontDir() const { return baseDir + "conf/fonts/"; }
+  std::string getShaderDir() const { return baseDir + "shaders/"; }
+  uint32_t getPreferredX() const { return preferredX; }
+  uint32_t getPreferredY() const { return preferredY; }
+  uint32_t getPreferredWidth() const { return preferredWidth; }
+  uint32_t getPreferredHeight() const { return preferredHeight; }
+  bool getFastLoadShaders() const { return shaderBinaryFormat != 0; }
+  void setFastLoadShaders(uint32_t fmt) { shaderBinaryFormat = fmt; }
 };
 
 extern Prefs prefs;

--- a/src/util/Prefs.hh
+++ b/src/util/Prefs.hh
@@ -22,6 +22,7 @@ class Prefs {
 
   bool trySavingShader;  // set true first, if it fails, set false
 
+  std::string getBaseDir() const { return baseDir; }
   std::string getConfDir() const { return baseDir + "conf/"; }
   std::string getFontDir() const { return baseDir + "conf/fonts/"; }
   std::string getShaderDir() const { return baseDir + "shaders/"; }

--- a/src/xp/CMakeLists.txt
+++ b/src/xp/CMakeLists.txt
@@ -1,6 +1,5 @@
 set(grail-xp
   Calendar.cc
-  Stats.cc
   lzmadecode.cc
 )
 


### PR DESCRIPTION
Removes all calls to `getenv("GRAIL")` from core components of the library and replaces them with an alternative way to get the base directory to ensure the user doesn't need `GRAIL` set in the environment. See #51 for more information. 